### PR TITLE
Fixed Recoverable Error: Svea/Checkout/Plugin/Url object of class can…

### DIFF
--- a/Plugin/Url.php
+++ b/Plugin/Url.php
@@ -19,7 +19,7 @@ class Url
 
     public function afterGetCheckoutUrl($subject,$result)
     {
-        if (!$this->helper->isEnabled() && $this->helper->replaceCheckout()) {
+        if ($this->helper->isEnabled() && $this->helper->replaceCheckout()) {
             return $this->helper->getCheckoutUrl();
         }
 

--- a/Plugin/Url.php
+++ b/Plugin/Url.php
@@ -21,7 +21,7 @@ class Url
     {
 
         if (!$this->helper->isEnabled()) {
-            return $this;
+            return $result;
         }
 
         if ($this->helper->replaceCheckout()) {

--- a/Plugin/Url.php
+++ b/Plugin/Url.php
@@ -19,16 +19,10 @@ class Url
 
     public function afterGetCheckoutUrl($subject,$result)
     {
-
-        if (!$this->helper->isEnabled()) {
-            return $result;
-        }
-
-        if ($this->helper->replaceCheckout()) {
+        if (!$this->helper->isEnabled() && $this->helper->replaceCheckout()) {
             return $this->helper->getCheckoutUrl();
         }
 
         return $result;
-
     }
 }


### PR DESCRIPTION
Hi Dev,

Please acknowledge and merge my pull request to fix this critical issue. 

It occurs when a module is disabled on one website and the module plugin is still returning the object of plugin class instead of the result object. 