### PR TITLE
Fixing an issue that caused 500 error when invoicing

### DIFF
--- a/Model/Svea/Items.php
+++ b/Model/Svea/Items.php
@@ -435,14 +435,13 @@ class Items
     }
 
     /**
-     * @param Quote $quote
+     * @param $grandTotal
      *
      * @return $this
      * @throws CheckoutException
      */
-    public function validateTotals(Quote $quote)
+    public function validateTotals($grandTotal)
     {
-        $grandTotal = $quote->getGrandTotal();
         $calculatedTotal = 0;
         foreach ($this->_cart as $item) {
             /** @var $item OrderRow */
@@ -554,7 +553,7 @@ class Items
         $this->addDiscounts($quote->getCouponCode());
 
         try {
-            $this->validateTotals($quote);
+            $this->validateTotals($quote->getGrandTotal());
         } catch (\Exception $e) {
             throw $e;
         }


### PR DESCRIPTION
We noticed that when we tried to invoice an order from the admin panel we got  an 500 error:
```PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Svea\Checkout\Model\Svea\Items::validateTotals() must be an instance of Magento\Quote\Model\Quote, float given,```
Noticed that Quote was only passed 1 time when validateTotals() was called, in the other instances we passed float, so I rewrote the validateTotals() and changed the place where the argument was a Quote instance so it works with the new validateTotals().