### PR TITLE
Collect shipping rates by address from quote

### DIFF
--- a/Model/Checkout.php
+++ b/Model/Checkout.php
@@ -126,6 +126,9 @@ class Checkout extends Onepage
         // Set shipping method. It's required!
         $selectedShippingMethod = $this->checkAndChangeShippingMethod();
 
+        // Needed to calculate table rates
+        $shippingAddress->setCollectShippingRates(true);
+
         try {
             $quote->setTotalsCollectedFlag(false)->collectTotals()->save(); //REQUIRED (maybe shipping amount was changed)
         } catch (\Exception $e) {


### PR DESCRIPTION
Fixes #28

I think this corresponds to how shipping rates gets calculated in Magento 2 via REST API endpoints:

- POST /V1/carts/:cartId/totals-information: https://github.com/magento/magento2/blob/ab591597f860fdee5572d3894c649100e42d884c/app/code/Magento/Checkout/Model/TotalsInformationManagement.php#L56
- POST /V1/carts/mine/estimate-shipping-methods: https://github.com/magento/magento2/blob/ab591597f860fdee5572d3894c649100e42d884c/app/code/Magento/Quote/Model/ShippingMethodManagement.php#L328