### PR TITLE
Fixing an issue if only 1 stock left

### DIFF
--- a/Plugin/Quote/Model/Quote/Item/Processor.php
+++ b/Plugin/Quote/Model/Quote/Item/Processor.php
@@ -35,7 +35,7 @@ class Processor
             $item->setData(CartItemInterface::KEY_QTY, 0);
         }
 
-        if ($item->getQuote()->getSveaClientOrderNumber() === null) {
+        if ($item->getQuote()->getSveaClientOrderNumber() === null && ($item->getQty() != $candidate->getCartQty())) {
             $item->addQty($candidate->getCartQty());
         }
 


### PR DESCRIPTION
We got an error "The requested qty is not available” in the checkout if we put only 1 stock in some sizes in configurable product and no backorder.