### PR TITLE
Add fallback for null values to empty string

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -531,7 +531,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 
     protected function splitStringToArray($values)
     {
-        return preg_split("#\s*[ ,;]\s*#", $values, -1, PREG_SPLIT_NO_EMPTY);
+        return preg_split("#\s*[ ,;]\s*#", $values ?? "", -1, PREG_SPLIT_NO_EMPTY);
     }
 
     /**


### PR DESCRIPTION
Fixes an error caused by null values for parameter #2 in `preg_replace()` being deprecated as of PHP8.1.

`{main} {"exception":"[object] (Exception(code: 0): Deprecated Functionality: preg_split(): Passing null to parameter #2 ($subject) of type string is deprecated in /var/www/project/www/vendor/sveawebpay/nwt-magento2-checkout/Helper/Data.php on line 534 at /var/www/project/www/vendor/magento/framework/App/ErrorHandler.php:62)"} []`