### PR TITLE
Add strict CSP enforcement and nonce support for inline scripts

### DIFF
--- a/ViewModel/Checkout/NonceProvider.php
+++ b/ViewModel/Checkout/NonceProvider.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace Svea\Checkout\ViewModel\Checkout;
+
+use Magento\Csp\Helper\CspNonceProvider;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\View\Element\Block\ArgumentInterface;
+
+/**
+ * ViewModel providing a CSP nonce for use in checkout templates.
+ */
+class NonceProvider implements ArgumentInterface
+{
+    /**
+     * CSP nonce provider helper.
+     *
+     * @var CspNonceProvider
+     */
+    private $cspNonceProvider;
+
+    /**
+     * Constructor.
+     *
+     * @param CspNonceProvider $cspNonceProvider CSP nonce provider helper.
+     */
+    public function __construct(CspNonceProvider $cspNonceProvider)
+    {
+        $this->cspNonceProvider = $cspNonceProvider;
+    }
+
+    /**
+     * Generate a Content Security Policy (CSP) nonce.
+     *
+     * Returns null if the nonce could not be generated.
+     *
+     * @return string|null
+     */
+    public function generateNonce(): ?string
+    {
+        try {
+            $nonce = $this->cspNonceProvider->generateNonce();
+        } catch (LocalizedException $e) {
+            return null;
+        }
+
+        return $nonce;
+    }
+}

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -40,5 +40,21 @@
                 <enforce_fallback>0</enforce_fallback>
             </sveanshift>
         </carriers>
+
+        <csp>
+            <mode>
+                <storefront_svea_checkout_index_index>
+                    <report_only>0</report_only>
+                </storefront_svea_checkout_index_index>
+            </mode>
+            <policies>
+                <storefront_svea_checkout_index_index>
+                    <scripts>
+                        <inline>0</inline>
+                        <event_handlers>1</event_handlers>
+                    </scripts>
+                </storefront_svea_checkout_index_index>
+            </policies>
+        </csp>
     </default>
 </config>

--- a/view/frontend/layout/svea_checkout_index_index.xml
+++ b/view/frontend/layout/svea_checkout_index_index.xml
@@ -181,13 +181,14 @@
                            ifconfig="checkout/cart/crosssell_enabled">
                         <arguments>
                             <argument name="type" xsi:type="string">crosssell</argument>
+                            <argument name="nonce_provider" xsi:type="object">Svea\Checkout\ViewModel\Checkout\NonceProvider</argument>
                         </arguments>
                     </block>
                 </container>
                 <!-- IFRAME -->
                 <container name="svea_checkout.main" as="svea_checkoutMain" label="Main svea_checkout Container"
                            htmlTag="div" htmlId="svea_checkoutMain">
-                    <block 
+                    <block
                         name="svea_checkout.svea.international"
                         ifconfig="svea_checkout/settings/international_flows/international_flow_active"
                         template="Svea_Checkout::checkout/international.phtml"

--- a/view/frontend/layout/svea_checkout_order_success.xml
+++ b/view/frontend/layout/svea_checkout_order_success.xml
@@ -37,7 +37,11 @@
             <container name="svea_checkoutSidebar" as="svea_checkoutSidebar" label="SveacCheckout Sidebar" htmlTag="div"
                        htmlId="svea_checkoutSidebar">
                 <block class="Svea\Checkout\Block\Success" name="svea_checkout_success" template="success.phtml"
-                       cacheable="false"/>
+                       cacheable="false">
+                    <arguments>
+                        <argument name="nonce_provider" xsi:type="object">Svea\Checkout\ViewModel\Checkout\NonceProvider</argument>
+                    </arguments>
+                </block>
                 <block class="Magento\GoogleAdwords\Block\Code" name="google.adwords.code" template="code.phtml"/>
             </container>
         </referenceContainer>

--- a/view/frontend/templates/product/list/items.phtml
+++ b/view/frontend/templates/product/list/items.phtml
@@ -6,8 +6,13 @@
 
 // @codingStandardsIgnoreFile
 
-/* @var $block \Svea\Checkout\Block\Checkout\Cart\Crosssell */
+/** @var \Svea\Checkout\Block\Checkout\Cart\Crosssell $block */
+/** @var \Svea\Checkout\ViewModel\Checkout\NonceProvider $nonceProvider */
+
 use Magento\Framework\App\Action\Action;
+
+$nonceProvider = $block->getNonceProvider();
+$nonce = $nonceProvider->generateNonce();
 ?>
 
 <?php
@@ -129,7 +134,7 @@ switch ($type = $block->getType()) {
         </div>
     </div>
 </div>
-<script>
+<script <?php echo $nonce ? 'nonce="' . $nonce . '"' : ''; ?>>
     require([
         'jquery',
         'slick'

--- a/view/frontend/templates/success.phtml
+++ b/view/frontend/templates/success.phtml
@@ -2,9 +2,13 @@
 // @codingStandardsIgnoreFile
 
 ?>
-<?php /** @var \Svea\Checkout\Block\Success $block */
+<?php
+/** @var \Svea\Checkout\Block\Success $block */
+/** @var \Svea\Checkout\ViewModel\Checkout\NonceProvider $nonceProvider */
 $orderId = $block->getOrderId();
 $realId = $block->getRealOrderId();
+$nonceProvider = $block->getNonceProvider();
+$nonce = $nonceProvider->generateNonce();
 ?>
 <div class="checkout-success" id="svea-checkout-success">
     <?php if ($block->getOrderId()): ?>
@@ -116,7 +120,7 @@ $realId = $block->getRealOrderId();
         </div>
     </div>
 </div>
-<script>
+<script <?php echo $nonce ? 'nonce="' . $nonce . '"' : ''; ?>>
     require([
         'jquery',
         'Magento_Customer/js/customer-data'


### PR DESCRIPTION
## Fixes Issue
Fixes #97 - Add Content Security Policy (CSP) enforcement and nonce support.

Edit: it doesn't fix the issue since there's an inline script generated by the iframe snippet, see [comment](https://github.com/sveawebpay/nwt-magento2-checkout/pull/98#issuecomment-2801099254) below.

## Changes
This PR adds the necessary CSP configuration to implement strict CSP enforcement and ensure inline scripts receive nonce attributes, aligning with Magento's enhanced security practices and PCI 4.0 compliance.

1. Added CSP configuration in `etc/config.xml`:
   - Set `report_only=0` to actively enforce CSP restrictions instead of just reporting
   - Configured CSP enforcement for the Svea checkout page
   - Disabled inline scripts without nonces
   - Enabled event handlers

## Before/After examples:
**Before:**
```html
<script>
    window.cookiesConfig = window.cookiesConfig || {};
    window.cookiesConfig.secure = true;
</script>
```

**After:**
```html
<script nonce="OTVhc25hNmN2bmFyM2R4eTdodG5tcWx2dTFqbW81MTQ&#x3D;">
    window.cookiesConfig = window.cookiesConfig || {};
    window.cookiesConfig.secure = true;
</script>
```